### PR TITLE
added init command

### DIFF
--- a/core/cli/cli.js
+++ b/core/cli/cli.js
@@ -37,10 +37,6 @@ if (typeof argValue === 'undefined') {
     process.exit(1);
 }
 
-//process.on('unhandledRejection', err => {throw err});
-
-//start();
-
 function start() {
     const {opts, cwd} = get_cli_args();
 
@@ -164,29 +160,22 @@ async function createScaffold(projectName) {
     const pkgTemplate = jsonPkgTemplate(projectName);
     let currentDir = path.resolve(process.cwd(), projectName);
 
-    // add files to projectname/app/views
-    try {
-        let tempPath = path.resolve(currentDir, 'app', 'views');
-        let fileName = 'homeView.js';
-        await fs.outputFile(path.resolve(tempPath, fileName), viewTemplate);
-    } catch (err) {
-        console.log(err);
-    }
+    // add files to projectName/app/views
+    let viewPath = path.resolve(currentDir, 'app', 'views');
+    let viewFileName = 'homeView.js';
+    await fs.outputFile(path.resolve(viewPath, viewFileName), viewTemplate);
 
     // add files to projectName/app/pages
-    try {
-        let tempPath = path.resolve(currentDir, 'app', 'pages');
-        let fileName = 'homePage.html.js';
-        await fs.outputFile(path.resolve(tempPath, fileName), pageTemplate);
-    } catch (err) {
-        console.log(err);
-    }
+    let pagePath = path.resolve(currentDir, 'app', 'pages');
+    let pageFileName = 'homePage.html.js';
+    await fs.outputFile(path.resolve(pagePath, pageFileName), pageTemplate);
 
     // add files to projectName root directory
-    try {
-        let fileName = 'package.json';
-        await fs.outputFile(path.resolve(currentDir, fileName), pkgTemplate);
-    } catch (err) {
-        console.log(err);
-    }
+    let pkgFileName = 'package.json';
+    await fs.outputFile(path.resolve(currentDir, pkgFileName), pkgTemplate);
 }
+
+process.on('unhandledRejection', err => {
+    console.log(err);
+    process.exit(1);
+});

--- a/core/cli/cli.js
+++ b/core/cli/cli.js
@@ -2,7 +2,7 @@
 
 const program = require('commander');
 const pkg = require('./package.json');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 let argValue;
 
@@ -156,47 +156,37 @@ function green_checkmark() {
     return chalk.green('\u2714');
 }
 
-function createScaffold(projectName) {
+async function createScaffold(projectName) {
     const {homeViewTemplate, homePageTemplate} = require('./templates/homeTemplate');
+    const {jsonPkgTemplate} = require('./templates/jsonPkgTemplate');
     const viewTemplate = homeViewTemplate();
     const pageTemplate = homePageTemplate(projectName);
-    let currentDir = path.normalize(path.resolve(process.cwd(), projectName));
+    const pkgTemplate = jsonPkgTemplate(projectName);
+    let currentDir = path.resolve(process.cwd(), projectName);
 
-    fs.mkdir(currentDir, (err) => {
-        if (err) {
-            console.log(err);
-        } else {
-            let tempPath = path.resolve(currentDir, 'app');
-            fs.mkdir(tempPath, (err) => {
-                if (err) {
-                    console.log(err);
-                } else {
-                    let viewPath = path.resolve(currentDir, 'app', 'views');
-                    fs.mkdir(viewPath, (err) => {
-                        if (err) {
-                            console.log(err);
-                        } else {
-                            let tempPath = path.resolve(currentDir, 'app', 'views', 'homeView.js');
-                            fs.writeFile(tempPath, viewTemplate, (err) => {
-                                if (err)
-                                    console.log(err);
-                            });
-                        }
-                    });
-                    let pagePath = path.resolve(currentDir, 'app', 'pages');
-                    fs.mkdir(pagePath, (err) => {
-                        if (err) {
-                            console.log(err);
-                        } else {
-                            let tempPath = path.resolve(currentDir, 'app', 'pages', 'homePage.js');
-                            fs.writeFile(tempPath, pageTemplate, (err) => {
-                                if (err)
-                                    console.log(err);
-                            });
-                        }
-                    });
-                }
-            });
-        }
-    });
+    // add files to projectname/app/views
+    try {
+        let tempPath = path.resolve(currentDir, 'app', 'views');
+        let fileName = 'homeView.js';
+        await fs.outputFile(path.resolve(tempPath, fileName), viewTemplate);
+    } catch (err) {
+        console.log(err);
+    }
+
+    // add files to projectName/app/pages
+    try {
+        let tempPath = path.resolve(currentDir, 'app', 'pages');
+        let fileName = 'homePage.html.js';
+        await fs.outputFile(path.resolve(tempPath, fileName), pageTemplate);
+    } catch (err) {
+        console.log(err);
+    }
+
+    // add files to projectName root directory
+    try {
+        let fileName = 'package.json';
+        await fs.outputFile(path.resolve(currentDir, fileName), pkgTemplate);
+    } catch (err) {
+        console.log(err);
+    }
 }

--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -8,6 +8,7 @@
     "@reframe/browser": "0.0.1-rc.5",
     "@reframe/server": "0.0.1-rc.5",
     "chalk": "^2.3.1",
+    "commander": "^2.14.1",
     "find-up": "^2.1.0",
     "lerna": "^2.5.1",
     "reassert": "latest"

--- a/core/cli/package.json
+++ b/core/cli/package.json
@@ -10,6 +10,7 @@
     "chalk": "^2.3.1",
     "commander": "^2.14.1",
     "find-up": "^2.1.0",
+    "fs-extra": "^5.0.0",
     "lerna": "^2.5.1",
     "reassert": "latest"
   },

--- a/core/cli/templates/homeTemplate.js
+++ b/core/cli/templates/homeTemplate.js
@@ -16,7 +16,8 @@ class HomeView extends Component {
     }
 }
 
-export default HomeView;`;
+export default HomeView;
+`;
 
     return template;
 }
@@ -33,7 +34,8 @@ const HomePage = {
     title: '${projectName}'
 };
 
-export default HomePage;`;
+export default HomePage;
+`;
 
     return template;
 }

--- a/core/cli/templates/homeTemplate.js
+++ b/core/cli/templates/homeTemplate.js
@@ -6,14 +6,6 @@ function homeViewTemplate() {
 `import React, { Component } from 'react';
 
 class HomeView extends Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-        };
-    };
-
-    static defaultProps = {
-    }
 
     render() {
         return (

--- a/core/cli/templates/homeTemplate.js
+++ b/core/cli/templates/homeTemplate.js
@@ -1,0 +1,47 @@
+module.exports = {homeViewTemplate, homePageTemplate};
+
+function homeViewTemplate() {
+    let template =
+
+`import React, { Component } from 'react';
+
+class HomeView extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+        };
+    };
+
+    static defaultProps = {
+    }
+
+    render() {
+        return (
+            <div>
+                <h3>Hello from Reframe!</h3>
+            </div>
+        );
+    }
+}
+
+export default HomeView;`;
+
+    return template;
+}
+
+function homePageTemplate(projectName) {
+    let template =
+
+`import React from 'react';
+import HomeView from '../views/homeView';
+
+const HomePage = {
+    route: '/',
+    view: HomeView,
+    title: '${projectName}'
+};
+
+export default HomePage;`;
+
+    return template;
+}

--- a/core/cli/templates/jsonPkgTemplate.js
+++ b/core/cli/templates/jsonPkgTemplate.js
@@ -1,0 +1,14 @@
+module.exports = {jsonPkgTemplate};
+
+function jsonPkgTemplate(projectName) {
+    let template =
+`{
+    "name": "${projectName}",
+    "dependencies": {
+        "react": "^16.2.0"
+    },
+    "private": true
+}`;
+
+    return template;
+}

--- a/core/cli/templates/jsonPkgTemplate.js
+++ b/core/cli/templates/jsonPkgTemplate.js
@@ -8,7 +8,8 @@ function jsonPkgTemplate(projectName) {
         "react": "^16.2.0"
     },
     "private": true
-}`;
+}
+`;
 
     return template;
 }

--- a/docs/customization-manual.md
+++ b/docs/customization-manual.md
@@ -102,10 +102,14 @@
 <br/>
 
 [Overview](/../../)<br/>
+[Reframe Rational](/docs/reframe-rational.md)<br/>
 [Usage Manual](/docs/usage-manual.md)<br/>
-[Customization Manual](/docs/customization-manual.md)
+[Customization Manual](/docs/customization-manual.md)<br/>
+[Plugins](/docs/plugins.md)
 
 <br/>
+
+# Customization Manual
 
 The customization manual acts as reference for advanced Reframe customization. Basic customization are covered in the Usage Manual.
 
@@ -126,8 +130,6 @@ And if you replace all three packages, then you effectively got rid of Reframe.
 
 The customizing manual gives a good overview of how packages can be re-written but partially lacks detailed information.
 Open a GitHub issue to get detailed info and support.
-
-# Customization Manual
 
 ##### Contents
 

--- a/docs/customization-manual.template.md
+++ b/docs/customization-manual.template.md
@@ -1,9 +1,11 @@
 !INLINE ./header.md --hide-source-path
 
 !MENU
-!MENU_ORDER 30
+!MENU_ORDER 40
 
 <br/>
+
+# Customization Manual
 
 The customization manual acts as reference for advanced Reframe customization. Basic customization are covered in the Usage Manual.
 
@@ -24,8 +26,6 @@ And if you replace all three packages, then you effectively got rid of Reframe.
 
 The customizing manual gives a good overview of how packages can be re-written but partially lacks detailed information.
 Open a GitHub issue to get detailed info and support.
-
-# Customization Manual
 
 ##### Contents
 

--- a/docs/overview.template.md
+++ b/docs/overview.template.md
@@ -13,33 +13,25 @@
 
  - [What is Reframe](#what-is-reframe)
  - [Why Reframe](#why-reframe)
-   - [Ease of Use](#ease-of-use)
-   - [Universality](#universality)
-   - [Customization](#customization)
-   - [Easy Escape](#easy-escape)
-   - [Performance](#performance)
- - [Reframe Project Scope](#reframe-project-scope)
- - [Plugins](#plugins)
  - [Quick Start](#quick-start)
-
 
 
 ### What is Reframe
 
 Reframe allows you to create web apps by defining so called "page configs".
-Reframe then takes care of the rest: It automatically transpiles, bundles, serves, and routes your pages.
+Reframe then takes care of the rest: It automatically transpiles, bundles, routes, renders, and serves your pages.
 
 ~~~jsx
 // We define a page config to create a landing page
 const LandingPage = {
-    // Page's URL
-    route: '/',
+  // Page's URL
+  route: '/',
 
-    // Page's React component
-    view: () => <div>Welcome to Reframe</div>,
+  // Page's React component
+  view: () => <div>Welcome to Reframe</div>,
 
-    // Page's <title>
-    title: 'Welcome'
+  // Page's <title>
+  title: 'Welcome'
 };
 ~~~
 
@@ -52,8 +44,25 @@ You can create a React web app with **no build configuration** and **no server c
 
 > All you need to create a web app is one React component and one page config per page.
 
-And, if you need to, **everything is customizable**:
-You can customize the transpiling & bundling, the server, the browser entry, the Node.js entry, etc.
+Let's create a web app by defining a page config `HelloPage`:
+
+~~~jsx
+// ~/tmp/reframe-playground/pages/HelloPage.html.js
+
+!INLINE ../examples/pages/HelloPage.html.js --hide-source-path
+~~~
+
+The `reframe` CLI does the rest:
+
+<p align="center">
+    <img src='https://github.com/brillout/reframe/raw/master/docs/images/reframe_overview_screenshot.png?sanitize=true' width=1200 style="max-width:100%;"/>
+</p>
+
+Reframe did the following:
+ - Reframe searched for a `pages/` directory and found one at `~/tmp/reframe-playground/pages`.
+ - Reframe read the `pages/` directory and found our page config at `~/tmp/reframe-playground/pages/HelloPage.html.js`.
+ - Reframe used webpack to transpile `HelloPage.html.js`.
+ - Reframe started a Node.js/hapi server serving all static assets and rendering and serving our page's HTML.
 
 With Reframe you can create:
 
@@ -79,267 +88,43 @@ Reframe generates a certain type of app depending on how you configure your page
 For example, if you add `htmlIsStatic: true` to a page config, then that page's HTML is rendered at build-time instead of request-time.
 So, creating a static app is simply a matter of setting `htmlIsStatic: true` to all page configs.
 
-Let's create a web app by defining a page config `HelloPage`:
-
-~~~jsx
-// ~/tmp/reframe-playground/pages/HelloPage.html.js
-
-!INLINE ../examples/pages/HelloPage.html.js --hide-source-path
-~~~
-
-The `reframe` CLI does the rest:
-
-<p align="center">
-    <img src='https://github.com/brillout/reframe/raw/master/docs/images/reframe_overview_screenshot.png?sanitize=true' width=1200 style="max-width:100%;"/>
-</p>
-
-Reframe did the following:
- - Reframe searched for a `pages/` directory and found one at `~/tmp/reframe-playground/pages`.
- - Reframe read the `pages/` directory and found our page config at `~/tmp/reframe-playground/pages/HelloPage.html.js`.
- - Reframe used webpack to transpile `HelloPage.html.js`.
- - Reframe started a Node.js/hapi server serving all static assets and rendering and serving our page's HTML.
-
 The "Quick Start" section below gives a step-by-step guide to create a React app with Reframe.
+
 
 ### Why Reframe
 
- - [Ease of Use](#ease-of-use)
- - [Universality](#universality)
- - [Customization](#customization)
- - [Easy Escape](#easy-escape)
- - [Performance](#performance)
-
-#### Ease of Use
-
-Creating a React app is simply a matter of creating React components and page configs.
-The "Quick Start" section below shows how easy it is.
-
-#### Universality
-
-A fundamental aspect of the page config is that it allows you to configure a page to be what we call "HTML-static", "HTML-dynamic", "DOM-static" and "DOM-dynamic":
- - *HTML-static*
+ - **Easy**
    <br/>
-   The page is rendered to HTML at build-time.
+   Create web apps by simply defining page configs and React components.
+   The Quick Start section bellow shows how easy it is.
+ - **Universal**
    <br/>
-   (In other words, the page is rendered to HTML only once, when Reframe is building the frontend.)
- - *HTML-dynamic*
+   Reframe is the only framework that supports all types of apps.
+   Instead of learning different frameworks to create different types of apps,
+   you learn Reframe once to be able to create all types of apps.
+ - **Escapable**
    <br/>
-   The page is rendered to HTML at request-time.
+   Every framework can be escaped from, but the escape-cost can vary dramatically.
+   Reframe has been designed to have a very low escape-cost.
+   If you are afraid of being locked into a framework, then Reframe could be the right choice for you.
+ - **Plugins**
    <br/>
-   (In other words, the page is (re-)rendered to HTML every time the user requests the page.)
- - *DOM-static*
+   Plugins can modify Reframe to a great extent.
+   There are plugins for using Reframe with React Router v4, TypeScript, PostCSS, etc.
+ - **Customizable**
    <br/>
-   The page is not hydrated.
+   Reframe allows you to easily and fully customize the webpack config, the server, the browser entry, the Node.js entry, the routing, etc.
+ - **Performance**
    <br/>
-   (In other words, the DOM doesn't have any React component attached to it and the DOM will not change.)
- - *DOM-dynamic*
-   <br/>
-   The page is hydrated.
-   <br/>
-   (In other words, React components are attached to the DOM and the page's DOM will eventually be updated by React.)
+   Reframe creates high performance apps by doing
+   code splitting,
+   optimal HTTP caching,
+   by pre-rendering pages to HTML,
+   and by statically rendering views.
 
-This fine-grain control over the "static-ness" of your pages gives you the ability to implement all app types.
-
-For example, you can create:
- - Server-side rendered apps.
-   <br/>
-   (In other words HTML-dynamic apps: All pages are configured to be HTML-dynamic.)
- - Static websites.
-   <br/>
-   (In other words HTML-static apps: All pages are configured to be HTML-static.)
-   <br/>
-   Since all pages are rendered to HTML at build-time, no Node.js server is needed.
-   These apps can be deployed to static website hostings such as GitHub Pages or Netlify.
- - DOM-static apps
-   <br/>
-   (In other words, apps where all pages are configured to be DOM-static.)
-   <br/>
-   Since the page is not hydrated, React is not loaded in the browser.
-   No (or almost no) JavaScript is loaded in the browser.
- - Hybrid apps.
-   <br/>
-   An app can have pages of different types:
-   Some pages can be configured to be HTML-static, some pages to be HTML-dynamic, some others to be DOM-static, and some to be DOM-dynamic.
-   You can for example configure your landing page to be HTML-static and DOM-static,
-   your product page to be HTML-dynamic and DOM-static,
-   and your product search page to be HTML-static and DOM-dynamic.
-
-Reframe is the only React framework that supports all app types.
-
-> Instead of learning different frameworks to create different types of apps,
-> you learn Reframe once to be able to create all types of apps.
-
-#### Customization
-
-Reframe is designed with easy customization in mind,
-and the following examples are easy to achieve:
- - Custom server
-   - Add server endpoints: RESTful/GraphQL API endpoints, authentication endpoints, etc.
-   - Custom hapi server config. (Reframe uses the hapi server framework by default.)
-   - Use a process manager such as PM2.
-   - etc.
- - Custom browser JavaScript
-   - Add error logging, analytics, etc.
-   - Full control of the hydration process.
-   - etc.
- - Custom transpiling & bundling
-   - Reframe can be used with almost any webpack config. (Reframe assumes pretty much nothing about the webpack config.)
-   - TypeScript support
-   - CSS preprocessors support, such as PostCSS, SASS, etc.
-   - etc.
- - Custom routing library. (Reframe is based on React Router by default.)
- - Custom view library such as Preact.
-
-#### Easy Escape
-
-Every framework can be escaped from but the escape-cost can vary dramatically.
-The escape-cost can be measured by two criteria:
- 1. How much code can be re-used after the escape?
- 2. How progressively can the framework be escaped?
-
-For example, if no code can be re-used after escaping a framework, then that framework has a very high escape-cost.
-In other words, that framework strongly locks you in.
-
-Let's measure Reframe's escape-cost.
-
-###### Code re-use after escape
-
-Reframe is built on top of widely-used and high-quality "Do One Thing and Do It Well" (DOTADIW) libraries such as webpack, hapi, React, React Router, etc.
-
-Reframe mostly gets out of the way between your code and these DOTADIW libraries:
-With Reframe,
-most of the code you write directly uses these DOTADIW libraries, independently of Reframe.
-
-For example,
-you would add RESTFul API endpoints by directly using hapi's interface.
-The code implementing the RESTFul API is then entirely independent of Reframe and can be fully re-used after escaping Reframe.
-(Technically Reframe is, on the server-side, mostly just a hapi plugin; Most of your server code will use hapi directly, know nothing about Reframe, and will be re-usable after escaping Reframe.)
-
-> Most of your code can be re-used after escaping Reframe.
-
-When worrying about framework lock-in, one of the main question to ask yourself is "am I writing code against an interface introduced by the framework or against an interface of a DOTADIW library?".
-If the latter is the case, then you are not locking yourself into the framework.
-
-###### Progressive escape
-
-Reframe consists of three packages:
- - `@reframe/build` that transpiles code and bundles browser assets.
- - `@reframe/server` that creates the server.
- - `@reframe/browser` that handles the browser side and hydrates the page.
-
-Each of these packages can be replaced with code of your own.
-
-For example,
-you can replace Reframe's server `@reframe/server` with your own server implementation.
-At that point,
-you have full control over the server,
-while still using the rest of Reframe.
-
-Similarly,
-if you replace Reframe's build `@reframe/build` with your own build implementation,
-then you have full control over the build step,
-while still using the rest of Reframe.
-
-> Reframe can be escaped in a progressive manner.
-
-By replacing all these three packages with code of your own, you effectively escape Reframe entirely.
-
-The Customization Manual explains how to escape from these three packages and includes examples such as:
- - Entirely custom build using Rollup (instead of webpack and by getting rid of `@reframe/build`).
- - Entirely custom server using Express (instead of hapi and by getting rid of `@reframe/server`).
- - Entirely custom browser-side code (by getting rid of `@reframe/browser`).
-
-###### Meteor, the counter example
-
-On the other side of the escape-cost spectrum, there is Meteor.
-
-It consists of many parts that you can only use if you use the entire Meteor stack.
-For example, you can use its build system or its server only if you use Meteor in its entirety.
-This means that, if you want to escape Meteor, you will have to re-write all code related to these works-only-with-Meteor parts.
-
-It has also not been designed with loosely coupled parts;
-With Meteor, it's mostly either all-in or all-out.
-In other words, you can't escape in a progressive manner.
+The [Reframe Rational](/docs/reframe-rational.md) document goes into the details of these perks.
 
 
-
-#### Performance
-
-- **Code splitting**
-  <br/>
-  Every page loads two scripts:
-  One script that is shared and cached across all pages
-  (which includes common code such as React and polyfills)
-  and a second script that includes the React components of the page.
-  This means that a KB-heavy page won't affect the KB-size of other pages.
-- **Optimal HTTP caching**
-  <br/>
-  Every dynamic server response is cached with a ETag header,
-  and every static server response is indefinitely cached.
-  (Static assets are served under hashed URLs with the `Cache-Control` header set to `immutable` and `max-age`'s maximum value.)
-- **DOM-static pages**
-  <br/>
-  A page can be configured to be rendered only on the server.
-  These pages are faster to load as the page isn't hydrated and
-  React is not loaded in the browser.
-- **Partial DOM-dynamic pages**
-  <br/>
-  A page can be configured so that only certain parts of the page are hydrated.
-  This makes the hydration of the page quicker
-  and less JavaScript is loaded in the browser.
-  (Only the React components of the hydrated parts are loaded.)
-- **HTML-static pages**
-  <br/>
-  A page can be configured to be rendered to HTML at build-time instead of request-time.
-  In other words, the page is rendered to HTML only once, when Reframe is building the frontend.
-  The HTML is statically served and the load time is decreased.
-- **SSR**
-  <br/>
-  Pages are rendered to HTML before being hydrated, decreasing the (perceived) load time.
-
-
-
-### Reframe Project Scope
-
-Reframe takes care of:
-
- - **Building**
-   <br/>
-   Reframe transpiles and bundles. (Uses webpack.)
- - **Server**
-   <br/>
-   Reframe sets up a Node.js server serving static assets and your pages' HTML. (Uses hapi.)
- - **Routing**
-   <br/>
-   Reframe routes URLs to your pages.
-
-Reframe **doesn't** take care of:
-
- - View logic / state management.
-   <br/>
-   It's up to you to manage the state of your views (or use Redux / MobX).
- - Database.
-   <br/>
-   It's up to you to create, populate, and query databases.
-   (You can add RESTFul/GraphQL API endpoints to the hapi server that Reframe creates.)
-
-
-### Plugins
-
-###### Languages
- - [@reframe/typescript](/typescript) - Use Reframe with TypeScript.
- - [@reframe/postcss](/postcss) - Use Reframe with PostCSS.
-
-###### Routing
- - [@reframe/react-router](/react-router) - Use React Router's components.
- - [@reframe/crossroads](/crossroads) - Use Reframe with [Crossroads.js](https://github.com/millermedeiros/crossroads.js).
- - [@reframe/path-to-regexp](/path-to-regexp) - Use Reframe with [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp).
-
-###### Kits
- - [@reframe/default-kit](/default-kit) - Reframe's default kit.
-
-###### View renderers
- - [@reframe/react](/react) - Use Reframe with React.
 
 ### Quick Start
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,207 @@
+<!---
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+-->
+<div><p align="right"><sup>
+    <img src="https://github.com/brillout/reframe/raw/master/docs/images/online-icon.svg?sanitize=true" width="13" height="20"> Chat with Reframe author on <a href="https://discord.gg/kqXf65G">discord.gg/kqXf65G</a>
+</sup></p></div>
+
+[<p align="center"><img src="https://github.com/brillout/reframe/raw/master/docs/images/logo-with-title.svg?sanitize=true" width=450 height=94 style="max-width:100%;" alt="Reframe"/></p>](https://github.com/brillout/reframe)
+
+<div><p align="center">
+        Framework to create web apps with React.
+</p></div>
+
+<div><p align="center">
+    <b>Easy</b>
+    -
+    Create apps with page configs.
+    &nbsp;&nbsp;&nbsp;
+    <b>Universal</b>
+    -
+    Create all kinds of apps.
+    &nbsp;&nbsp;&nbsp;
+    <b>Escapable</b>
+    -
+    Easy & progressive escape.
+</p></div>
+
+<br/>
+
+[Overview](/../../)<br/>
+[Reframe Rational](/docs/reframe-rational.md)<br/>
+[Usage Manual](/docs/usage-manual.md)<br/>
+[Customization Manual](/docs/customization-manual.md)<br/>
+[Plugins](/docs/plugins.md)
+
+<br/>
+
+# Plugins
+
+List of Reframe plugins. Make a PR to add yours.
+
+###### Languages
+ - [@reframe/typescript](/plugins/typescript) - Use Reframe with TypeScript.
+ - [@reframe/postcss](/plugins/postcss) - Use Reframe with PostCSS.
+
+###### Routing
+ - [@reframe/react-router](/plugins/react-router) - Use React Router's components.
+ - [@reframe/crossroads](/plugins/crossroads) - Use Reframe with [Crossroads.js](https://github.com/millermedeiros/crossroads.js).
+ - [@reframe/path-to-regexp](/plugins/path-to-regexp) - Use Reframe with [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp).
+
+###### Kits
+ - [@reframe/default-kit](/plugins/default-kit) - Reframe's default kit.
+
+###### View renderers
+ - [@reframe/react](/plugins/react) - Use Reframe with React.
+
+<!---
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/plugins.template.md` instead.
+
+
+
+
+
+
+-->

--- a/docs/plugins.template.md
+++ b/docs/plugins.template.md
@@ -1,0 +1,25 @@
+!INLINE ./header.md --hide-source-path
+
+!MENU
+!MENU_ORDER 50
+
+<br/>
+
+# Plugins
+
+List of Reframe plugins. Make a PR to add yours.
+
+###### Languages
+ - [@reframe/typescript](/plugins/typescript) - Use Reframe with TypeScript.
+ - [@reframe/postcss](/plugins/postcss) - Use Reframe with PostCSS.
+
+###### Routing
+ - [@reframe/react-router](/plugins/react-router) - Use React Router's components.
+ - [@reframe/crossroads](/plugins/crossroads) - Use Reframe with [Crossroads.js](https://github.com/millermedeiros/crossroads.js).
+ - [@reframe/path-to-regexp](/plugins/path-to-regexp) - Use Reframe with [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp).
+
+###### Kits
+ - [@reframe/default-kit](/plugins/default-kit) - Reframe's default kit.
+
+###### View renderers
+ - [@reframe/react](/plugins/react) - Use Reframe with React.

--- a/docs/reframe-rational.md
+++ b/docs/reframe-rational.md
@@ -1,0 +1,401 @@
+<!---
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+-->
+<div><p align="right"><sup>
+    <img src="https://github.com/brillout/reframe/raw/master/docs/images/online-icon.svg?sanitize=true" width="13" height="20"> Chat with Reframe author on <a href="https://discord.gg/kqXf65G">discord.gg/kqXf65G</a>
+</sup></p></div>
+
+[<p align="center"><img src="https://github.com/brillout/reframe/raw/master/docs/images/logo-with-title.svg?sanitize=true" width=450 height=94 style="max-width:100%;" alt="Reframe"/></p>](https://github.com/brillout/reframe)
+
+<div><p align="center">
+        Framework to create web apps with React.
+</p></div>
+
+<div><p align="center">
+    <b>Easy</b>
+    -
+    Create apps with page configs.
+    &nbsp;&nbsp;&nbsp;
+    <b>Universal</b>
+    -
+    Create all kinds of apps.
+    &nbsp;&nbsp;&nbsp;
+    <b>Escapable</b>
+    -
+    Easy & progressive escape.
+</p></div>
+
+<br/>
+
+[Overview](/../../)<br/>
+[Reframe Rational](/docs/reframe-rational.md)<br/>
+[Usage Manual](/docs/usage-manual.md)<br/>
+[Customization Manual](/docs/customization-manual.md)<br/>
+[Plugins](/docs/plugins.md)
+
+<br/>
+
+# Reframe Rational
+
+The Reframe Rational explains in details why someone would want to use Reframe.
+This is Reframe's raison d'etre.
+
+##### Contents
+
+ - [Easy](#easy)
+ - [Universal](#universal)
+ - [Escapable](#escapable)
+ - [Customizable](#customizable)
+ - [Performant](#performant)
+
+
+#### Easy
+
+Creating a React app is simply a matter of creating React components and page configs.
+And creating a certain type of app is simply a matter of configurating your page configs.
+
+
+#### Universal
+
+A fundamental aspect of the page config is that it allows you to configure a page to be what we call "HTML-static", "HTML-dynamic", "DOM-static" and "DOM-dynamic":
+ - *HTML-static*
+   <br/>
+   The page is rendered to HTML at build-time.
+   <br/>
+   (In other words, the page is rendered to HTML only once, when Reframe is building the frontend.)
+ - *HTML-dynamic*
+   <br/>
+   The page is rendered to HTML at request-time.
+   <br/>
+   (In other words, the page is (re-)rendered to HTML every time the user requests the page.)
+ - *DOM-static*
+   <br/>
+   The page is not hydrated.
+   <br/>
+   (In other words, the DOM doesn't have any React component attached to it and the DOM will not change.)
+ - *DOM-dynamic*
+   <br/>
+   The page is hydrated.
+   <br/>
+   (In other words, React components are attached to the DOM and the page's DOM will eventually be updated by React.)
+
+This fine-grain control over the "static-ness" of your pages gives you the ability to implement all app types.
+
+For example, you can create:
+ - Server-side rendered apps.
+   <br/>
+   (In other words HTML-dynamic apps: All pages are configured to be HTML-dynamic.)
+ - Static apps.
+   <br/>
+   (In other words HTML-static apps: All pages are configured to be HTML-static.)
+   <br/>
+   Since all pages are rendered to HTML at build-time, no Node.js server is needed.
+   These apps can be deployed to static website hostings such as GitHub Pages or Netlify.
+ - DOM-static apps.
+   <br/>
+   (In other words, apps where all pages are configured to be DOM-static.)
+   <br/>
+   Since the page is not hydrated, React is not loaded in the browser.
+   No (or almost no) JavaScript is loaded in the browser.
+ - Static websites.
+   <br/>
+   (In other words HTML-static and DOM-static apps: All pages are configured to be HTML-static and DOM-static.)
+   <br/>
+   These apps can be deployed to static website hostings as well.
+ - Hybrid apps.
+   <br/>
+   An app can have pages of different types:
+   Some pages can be configured to be HTML-static, some pages to be HTML-dynamic, some others to be DOM-static, and some to be DOM-dynamic.
+   You can for example configure your landing page to be HTML-static and DOM-static,
+   your product page to be HTML-dynamic and DOM-static,
+   and your product search page to be HTML-static and DOM-dynamic.
+
+Reframe is the only React framework that supports all app types.
+
+> Instead of learning different frameworks to create different types of apps,
+> you learn Reframe once to be able to create all types of apps.
+
+
+#### Escapable
+
+Every framework can be escaped from but the escape-cost can vary dramatically.
+The escape-cost can be measured by two criteria:
+ 1. How much code can be re-used after the escape?
+ 2. How progressively can the framework be escaped?
+
+For example, if no code can be re-used after escaping a framework, then that framework has a very high escape-cost.
+In other words, that framework strongly locks you in.
+
+Let's measure Reframe's escape-cost.
+
+###### Code re-use after escape
+
+Reframe is built on top of widely-used and high-quality "Do One Thing and Do It Well" (DOTADIW) libraries such as webpack, hapi, React, React Router, etc.
+
+Reframe mostly gets out of the way between your code and these DOTADIW libraries:
+With Reframe,
+most of the code you write directly uses these DOTADIW libraries, independently of Reframe.
+
+For example,
+you would add RESTFul API endpoints by directly using hapi's interface.
+The code implementing the RESTFul API is then entirely independent of Reframe and can be fully re-used after escaping Reframe.
+(Technically Reframe is, on the server-side, mostly just a hapi plugin; Most of your server code will use hapi directly, know nothing about Reframe, and will be re-usable after escaping Reframe.)
+
+> Most of your code can be re-used after escaping Reframe.
+
+When worrying about framework lock-in, one of the main question to ask yourself is "am I writing code against an interface introduced by the framework or against an interface of a DOTADIW library?".
+If the latter is the case, then you are not locking yourself into the framework.
+
+###### Progressive escape
+
+Reframe consists of three packages:
+ - `@reframe/build` that transpiles code and bundles browser assets.
+ - `@reframe/server` that creates the server.
+ - `@reframe/browser` that handles the browser side and hydrates the page.
+
+Each of these packages can be replaced with code of your own.
+
+For example,
+you can replace Reframe's server `@reframe/server` with your own server implementation.
+At that point,
+you have full control over the server,
+while still using the rest of Reframe.
+
+Similarly,
+if you replace Reframe's build `@reframe/build` with your own build implementation,
+then you have full control over the build step,
+while still using the rest of Reframe.
+
+> Reframe can be escaped in a progressive manner.
+
+By replacing all these three packages with code of your own, you effectively escape Reframe entirely.
+
+The Customization Manual explains how to escape from these three packages and includes examples such as:
+ - Entirely custom build using Rollup (instead of webpack and by getting rid of `@reframe/build`).
+ - Entirely custom server using Express (instead of hapi and by getting rid of `@reframe/server`).
+ - Entirely custom browser-side code (by getting rid of `@reframe/browser`).
+
+###### Meteor, the counter example
+
+On the other side of the escape-cost spectrum, there is Meteor.
+
+It consists of many parts that you can only use if you use the entire Meteor stack.
+For example, you can use its build system or its server only if you use Meteor in its entirety.
+This means that, if you want to escape Meteor, you will have to re-write all code related to these works-only-with-Meteor parts.
+
+It has also not been designed with loosely coupled parts;
+With Meteor, it's mostly either all-in or all-out.
+In other words, you can't escape in a progressive manner.
+
+
+#### Customizable
+
+Reframe is designed with easy customization in mind,
+and the following examples are easy to achieve:
+ - Custom server
+   - Add server endpoints: RESTful/GraphQL API endpoints, authentication endpoints, etc.
+   - Custom hapi server config. (Reframe uses the hapi server framework by default.)
+   - Use a process manager such as PM2.
+   - etc.
+ - Custom browser JavaScript
+   - Add error logging, analytics, etc.
+   - Full control of the hydration process.
+   - etc.
+ - Custom transpiling & bundling
+   - Reframe can be used with almost any webpack config. (Reframe assumes pretty much nothing about the webpack config.)
+   - TypeScript support
+   - CSS preprocessors support, such as PostCSS, SASS, etc.
+   - etc.
+ - Custom routing library. (Reframe is based on React Router by default.)
+ - Custom view library such as Preact.
+
+The "Usage Manual" and "Customization Manual" documents cover these possibilites.
+
+
+#### Performant
+
+- **Code splitting**
+  <br/>
+  Every page loads two scripts:
+  One script that is shared and cached across all pages
+  (which includes common code such as React and polyfills)
+  and a second script that includes the React components of the page.
+  This means that a KB-heavy page won't affect the KB-size of other pages.
+- **Optimal HTTP caching**
+  <br/>
+  Every dynamic server response is cached with a ETag header,
+  and every static server response is indefinitely cached.
+  (Static assets are served under hashed URLs with the `Cache-Control` header set to `immutable` and `max-age`'s maximum value.)
+- **DOM-static pages**
+  <br/>
+  A page can be configured to be rendered only on the server.
+  These pages are faster to load as the page isn't hydrated and
+  React is not loaded in the browser.
+- **Partial DOM-dynamic pages**
+  <br/>
+  A page can be configured so that only certain parts of the page are hydrated.
+  This makes the hydration of the page quicker
+  and less JavaScript is loaded in the browser.
+  (Only the React components of the hydrated parts are loaded.)
+- **HTML-static pages**
+  <br/>
+  A page can be configured to be rendered to HTML at build-time instead of request-time.
+  In other words, the page is rendered to HTML only once, when Reframe is building the frontend.
+  The HTML is statically served and the load time is decreased.
+- **SSR**
+  <br/>
+  Pages are rendered to HTML before being hydrated, decreasing the (perceived) load time.
+
+
+
+<!---
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+
+
+
+
+
+
+    WARNING, READ THIS.
+    This is a computed file. Do not edit.
+    Edit `/docs/reframe-rational.template.md` instead.
+
+
+
+
+
+
+-->

--- a/docs/reframe-rational.template.md
+++ b/docs/reframe-rational.template.md
@@ -1,0 +1,219 @@
+!INLINE ./header.md --hide-source-path
+
+!MENU
+!MENU_ORDER 20
+
+<br/>
+
+# Reframe Rational
+
+The Reframe Rational explains in details why someone would want to use Reframe.
+This is Reframe's raison d'etre.
+
+##### Contents
+
+ - [Easy](#easy)
+ - [Universal](#universal)
+ - [Escapable](#escapable)
+ - [Customizable](#customizable)
+ - [Performant](#performant)
+
+
+#### Easy
+
+Creating a React app is simply a matter of creating React components and page configs.
+And creating a certain type of app is simply a matter of configurating your page configs.
+
+
+#### Universal
+
+A fundamental aspect of the page config is that it allows you to configure a page to be what we call "HTML-static", "HTML-dynamic", "DOM-static" and "DOM-dynamic":
+ - *HTML-static*
+   <br/>
+   The page is rendered to HTML at build-time.
+   <br/>
+   (In other words, the page is rendered to HTML only once, when Reframe is building the frontend.)
+ - *HTML-dynamic*
+   <br/>
+   The page is rendered to HTML at request-time.
+   <br/>
+   (In other words, the page is (re-)rendered to HTML every time the user requests the page.)
+ - *DOM-static*
+   <br/>
+   The page is not hydrated.
+   <br/>
+   (In other words, the DOM doesn't have any React component attached to it and the DOM will not change.)
+ - *DOM-dynamic*
+   <br/>
+   The page is hydrated.
+   <br/>
+   (In other words, React components are attached to the DOM and the page's DOM will eventually be updated by React.)
+
+This fine-grain control over the "static-ness" of your pages gives you the ability to implement all app types.
+
+For example, you can create:
+ - Server-side rendered apps.
+   <br/>
+   (In other words HTML-dynamic apps: All pages are configured to be HTML-dynamic.)
+ - Static apps.
+   <br/>
+   (In other words HTML-static apps: All pages are configured to be HTML-static.)
+   <br/>
+   Since all pages are rendered to HTML at build-time, no Node.js server is needed.
+   These apps can be deployed to static website hostings such as GitHub Pages or Netlify.
+ - DOM-static apps.
+   <br/>
+   (In other words, apps where all pages are configured to be DOM-static.)
+   <br/>
+   Since the page is not hydrated, React is not loaded in the browser.
+   No (or almost no) JavaScript is loaded in the browser.
+ - Static websites.
+   <br/>
+   (In other words HTML-static and DOM-static apps: All pages are configured to be HTML-static and DOM-static.)
+   <br/>
+   These apps can be deployed to static website hostings as well.
+ - Hybrid apps.
+   <br/>
+   An app can have pages of different types:
+   Some pages can be configured to be HTML-static, some pages to be HTML-dynamic, some others to be DOM-static, and some to be DOM-dynamic.
+   You can for example configure your landing page to be HTML-static and DOM-static,
+   your product page to be HTML-dynamic and DOM-static,
+   and your product search page to be HTML-static and DOM-dynamic.
+
+Reframe is the only React framework that supports all app types.
+
+> Instead of learning different frameworks to create different types of apps,
+> you learn Reframe once to be able to create all types of apps.
+
+
+#### Escapable
+
+Every framework can be escaped from but the escape-cost can vary dramatically.
+The escape-cost can be measured by two criteria:
+ 1. How much code can be re-used after the escape?
+ 2. How progressively can the framework be escaped?
+
+For example, if no code can be re-used after escaping a framework, then that framework has a very high escape-cost.
+In other words, that framework strongly locks you in.
+
+Let's measure Reframe's escape-cost.
+
+###### Code re-use after escape
+
+Reframe is built on top of widely-used and high-quality "Do One Thing and Do It Well" (DOTADIW) libraries such as webpack, hapi, React, React Router, etc.
+
+Reframe mostly gets out of the way between your code and these DOTADIW libraries:
+With Reframe,
+most of the code you write directly uses these DOTADIW libraries, independently of Reframe.
+
+For example,
+you would add RESTFul API endpoints by directly using hapi's interface.
+The code implementing the RESTFul API is then entirely independent of Reframe and can be fully re-used after escaping Reframe.
+(Technically Reframe is, on the server-side, mostly just a hapi plugin; Most of your server code will use hapi directly, know nothing about Reframe, and will be re-usable after escaping Reframe.)
+
+> Most of your code can be re-used after escaping Reframe.
+
+When worrying about framework lock-in, one of the main question to ask yourself is "am I writing code against an interface introduced by the framework or against an interface of a DOTADIW library?".
+If the latter is the case, then you are not locking yourself into the framework.
+
+###### Progressive escape
+
+Reframe consists of three packages:
+ - `@reframe/build` that transpiles code and bundles browser assets.
+ - `@reframe/server` that creates the server.
+ - `@reframe/browser` that handles the browser side and hydrates the page.
+
+Each of these packages can be replaced with code of your own.
+
+For example,
+you can replace Reframe's server `@reframe/server` with your own server implementation.
+At that point,
+you have full control over the server,
+while still using the rest of Reframe.
+
+Similarly,
+if you replace Reframe's build `@reframe/build` with your own build implementation,
+then you have full control over the build step,
+while still using the rest of Reframe.
+
+> Reframe can be escaped in a progressive manner.
+
+By replacing all these three packages with code of your own, you effectively escape Reframe entirely.
+
+The Customization Manual explains how to escape from these three packages and includes examples such as:
+ - Entirely custom build using Rollup (instead of webpack and by getting rid of `@reframe/build`).
+ - Entirely custom server using Express (instead of hapi and by getting rid of `@reframe/server`).
+ - Entirely custom browser-side code (by getting rid of `@reframe/browser`).
+
+###### Meteor, the counter example
+
+On the other side of the escape-cost spectrum, there is Meteor.
+
+It consists of many parts that you can only use if you use the entire Meteor stack.
+For example, you can use its build system or its server only if you use Meteor in its entirety.
+This means that, if you want to escape Meteor, you will have to re-write all code related to these works-only-with-Meteor parts.
+
+It has also not been designed with loosely coupled parts;
+With Meteor, it's mostly either all-in or all-out.
+In other words, you can't escape in a progressive manner.
+
+
+#### Customizable
+
+Reframe is designed with easy customization in mind,
+and the following examples are easy to achieve:
+ - Custom server
+   - Add server endpoints: RESTful/GraphQL API endpoints, authentication endpoints, etc.
+   - Custom hapi server config. (Reframe uses the hapi server framework by default.)
+   - Use a process manager such as PM2.
+   - etc.
+ - Custom browser JavaScript
+   - Add error logging, analytics, etc.
+   - Full control of the hydration process.
+   - etc.
+ - Custom transpiling & bundling
+   - Reframe can be used with almost any webpack config. (Reframe assumes pretty much nothing about the webpack config.)
+   - TypeScript support
+   - CSS preprocessors support, such as PostCSS, SASS, etc.
+   - etc.
+ - Custom routing library. (Reframe is based on React Router by default.)
+ - Custom view library such as Preact.
+
+The "Usage Manual" and "Customization Manual" documents cover these possibilites.
+
+
+#### Performant
+
+- **Code splitting**
+  <br/>
+  Every page loads two scripts:
+  One script that is shared and cached across all pages
+  (which includes common code such as React and polyfills)
+  and a second script that includes the React components of the page.
+  This means that a KB-heavy page won't affect the KB-size of other pages.
+- **Optimal HTTP caching**
+  <br/>
+  Every dynamic server response is cached with a ETag header,
+  and every static server response is indefinitely cached.
+  (Static assets are served under hashed URLs with the `Cache-Control` header set to `immutable` and `max-age`'s maximum value.)
+- **DOM-static pages**
+  <br/>
+  A page can be configured to be rendered only on the server.
+  These pages are faster to load as the page isn't hydrated and
+  React is not loaded in the browser.
+- **Partial DOM-dynamic pages**
+  <br/>
+  A page can be configured so that only certain parts of the page are hydrated.
+  This makes the hydration of the page quicker
+  and less JavaScript is loaded in the browser.
+  (Only the React components of the hydrated parts are loaded.)
+- **HTML-static pages**
+  <br/>
+  A page can be configured to be rendered to HTML at build-time instead of request-time.
+  In other words, the page is rendered to HTML only once, when Reframe is building the frontend.
+  The HTML is statically served and the load time is decreased.
+- **SSR**
+  <br/>
+  Pages are rendered to HTML before being hydrated, decreasing the (perceived) load time.
+
+

--- a/docs/usage-manual.md
+++ b/docs/usage-manual.md
@@ -102,15 +102,17 @@
 <br/>
 
 [Overview](/../../)<br/>
+[Reframe Rational](/docs/reframe-rational.md)<br/>
 [Usage Manual](/docs/usage-manual.md)<br/>
-[Customization Manual](/docs/customization-manual.md)
+[Customization Manual](/docs/customization-manual.md)<br/>
+[Plugins](/docs/plugins.md)
 
 <br/>
 
+# Usage Manual
+
 The usage manual acts as reference for using Reframe wihtout advanced customization.
 This manual covers most common use cases.
-
-# Usage Manual
 
 #### Contents
 
@@ -355,14 +357,13 @@ const HelloComponent = (
 );
 
 const HelloPage = {
+  // Reframe follows the same route string syntax than React Router.
+  // React Router's components `<Route>`, `<Switch>`, etc. can be used
+  // by adding the plugin `@reframe/react-router`.
+  route: '/hello/:name',
+
   // Page's React component
   view: HelloComponent,
-
-  // Page's URL.
-  // Reframe follows the same route string syntax than React Router.
-  // (This route is analogous to `<Route path="/hello/:name" component={HelloComponent}/>`.)
-  // (To use React Router's components `<Route>`, `<Switch>`, etc. add the plugin `@reframe/react-router`.)
-  route: '/hello/:name',
 
   // Page's <title>
   title: 'Hi there',

--- a/docs/usage-manual.template.md
+++ b/docs/usage-manual.template.md
@@ -1,14 +1,14 @@
 !INLINE ./header.md --hide-source-path
 
 !MENU
-!MENU_ORDER 20
+!MENU_ORDER 30
 
 <br/>
 
+# Usage Manual
+
 The usage manual acts as reference for using Reframe wihtout advanced customization.
 This manual covers most common use cases.
-
-# Usage Manual
 
 #### Contents
 

--- a/examples/pages/HelloPage.html.js
+++ b/examples/pages/HelloPage.html.js
@@ -11,14 +11,13 @@ const HelloComponent = (
 );
 
 const HelloPage = {
+  // Reframe follows the same route string syntax than React Router.
+  // React Router's components `<Route>`, `<Switch>`, etc. can be used
+  // by adding the plugin `@reframe/react-router`.
+  route: '/hello/:name',
+
   // Page's React component
   view: HelloComponent,
-
-  // Page's URL.
-  // Reframe follows the same route string syntax than React Router.
-  // (This route is analogous to `<Route path="/hello/:name" component={HelloComponent}/>`.)
-  // (To use React Router's components `<Route>`, `<Switch>`, etc. add the plugin `@reframe/react-router`.)
-  route: '/hello/:name',
 
   // Page's <title>
   title: 'Hi there',

--- a/readme.md
+++ b/readme.md
@@ -102,8 +102,10 @@
 <br/>
 
 [Overview](/../../)<br/>
+[Reframe Rational](/docs/reframe-rational.md)<br/>
 [Usage Manual](/docs/usage-manual.md)<br/>
-[Customization Manual](/docs/customization-manual.md)
+[Customization Manual](/docs/customization-manual.md)<br/>
+[Plugins](/docs/plugins.md)
 
 <br/>
 
@@ -113,33 +115,25 @@
 
  - [What is Reframe](#what-is-reframe)
  - [Why Reframe](#why-reframe)
-   - [Ease of Use](#ease-of-use)
-   - [Universality](#universality)
-   - [Customization](#customization)
-   - [Easy Escape](#easy-escape)
-   - [Performance](#performance)
- - [Reframe Project Scope](#reframe-project-scope)
- - [Plugins](#plugins)
  - [Quick Start](#quick-start)
-
 
 
 ### What is Reframe
 
 Reframe allows you to create web apps by defining so called "page configs".
-Reframe then takes care of the rest: It automatically transpiles, bundles, serves, and routes your pages.
+Reframe then takes care of the rest: It automatically transpiles, bundles, routes, renders, and serves your pages.
 
 ~~~jsx
 // We define a page config to create a landing page
 const LandingPage = {
-    // Page's URL
-    route: '/',
+  // Page's URL
+  route: '/',
 
-    // Page's React component
-    view: () => <div>Welcome to Reframe</div>,
+  // Page's React component
+  view: () => <div>Welcome to Reframe</div>,
 
-    // Page's <title>
-    title: 'Welcome'
+  // Page's <title>
+  title: 'Welcome'
 };
 ~~~
 
@@ -152,8 +146,50 @@ You can create a React web app with **no build configuration** and **no server c
 
 > All you need to create a web app is one React component and one page config per page.
 
-And, if you need to, **everything is customizable**:
-You can customize the transpiling & bundling, the server, the browser entry, the Node.js entry, etc.
+Let's create a web app by defining a page config `HelloPage`:
+
+~~~jsx
+// ~/tmp/reframe-playground/pages/HelloPage.html.js
+
+import React from 'react';
+
+const HelloComponent = (
+  props => {
+    // Our route argument `name` is available at `props.route.args.name`
+    const name = props.route.args.name;
+    return (
+      <div>Hello {name}</div>
+    );
+  }
+);
+
+const HelloPage = {
+  // Reframe follows the same route string syntax than React Router.
+  // React Router's components `<Route>`, `<Switch>`, etc. can be used
+  // by adding the plugin `@reframe/react-router`.
+  route: '/hello/:name',
+
+  // Page's React component
+  view: HelloComponent,
+
+  // Page's <title>
+  title: 'Hi there',
+};
+
+export default HelloPage;
+~~~
+
+The `reframe` CLI does the rest:
+
+<p align="center">
+    <img src='https://github.com/brillout/reframe/raw/master/docs/images/reframe_overview_screenshot.png?sanitize=true' width=1200 style="max-width:100%;"/>
+</p>
+
+Reframe did the following:
+ - Reframe searched for a `pages/` directory and found one at `~/tmp/reframe-playground/pages`.
+ - Reframe read the `pages/` directory and found our page config at `~/tmp/reframe-playground/pages/HelloPage.html.js`.
+ - Reframe used webpack to transpile `HelloPage.html.js`.
+ - Reframe started a Node.js/hapi server serving all static assets and rendering and serving our page's HTML.
 
 With Reframe you can create:
 
@@ -179,293 +215,43 @@ Reframe generates a certain type of app depending on how you configure your page
 For example, if you add `htmlIsStatic: true` to a page config, then that page's HTML is rendered at build-time instead of request-time.
 So, creating a static app is simply a matter of setting `htmlIsStatic: true` to all page configs.
 
-Let's create a web app by defining a page config `HelloPage`:
-
-~~~jsx
-// ~/tmp/reframe-playground/pages/HelloPage.html.js
-
-import React from 'react';
-
-const HelloComponent = (
-  props => {
-    // Our route argument `name` is available at `props.route.args.name`
-    const name = props.route.args.name;
-    return (
-      <div>Hello {name}</div>
-    );
-  }
-);
-
-const HelloPage = {
-  // Page's React component
-  view: HelloComponent,
-
-  // Page's URL.
-  // Reframe follows the same route string syntax than React Router.
-  // (This route is analogous to `<Route path="/hello/:name" component={HelloComponent}/>`.)
-  // (To use React Router's components `<Route>`, `<Switch>`, etc. add the plugin `@reframe/react-router`.)
-  route: '/hello/:name',
-
-  // Page's <title>
-  title: 'Hi there',
-};
-
-export default HelloPage;
-~~~
-
-The `reframe` CLI does the rest:
-
-<p align="center">
-    <img src='https://github.com/brillout/reframe/raw/master/docs/images/reframe_overview_screenshot.png?sanitize=true' width=1200 style="max-width:100%;"/>
-</p>
-
-Reframe did the following:
- - Reframe searched for a `pages/` directory and found one at `~/tmp/reframe-playground/pages`.
- - Reframe read the `pages/` directory and found our page config at `~/tmp/reframe-playground/pages/HelloPage.html.js`.
- - Reframe used webpack to transpile `HelloPage.html.js`.
- - Reframe started a Node.js/hapi server serving all static assets and rendering and serving our page's HTML.
-
 The "Quick Start" section below gives a step-by-step guide to create a React app with Reframe.
+
 
 ### Why Reframe
 
- - [Ease of Use](#ease-of-use)
- - [Universality](#universality)
- - [Customization](#customization)
- - [Easy Escape](#easy-escape)
- - [Performance](#performance)
-
-#### Ease of Use
-
-Creating a React app is simply a matter of creating React components and page configs.
-The "Quick Start" section below shows how easy it is.
-
-#### Universality
-
-A fundamental aspect of the page config is that it allows you to configure a page to be what we call "HTML-static", "HTML-dynamic", "DOM-static" and "DOM-dynamic":
- - *HTML-static*
+ - **Easy**
    <br/>
-   The page is rendered to HTML at build-time.
+   Create web apps by simply defining page configs and React components.
+   The Quick Start section bellow shows how easy it is.
+ - **Universal**
    <br/>
-   (In other words, the page is rendered to HTML only once, when Reframe is building the frontend.)
- - *HTML-dynamic*
+   Reframe is the only framework that supports all types of apps.
+   Instead of learning different frameworks to create different types of apps,
+   you learn Reframe once to be able to create all types of apps.
+ - **Escapable**
    <br/>
-   The page is rendered to HTML at request-time.
+   Every framework can be escaped from, but the escape-cost can vary dramatically.
+   Reframe has been designed to have a very low escape-cost.
+   If you are afraid of being locked into a framework, then Reframe could be the right choice for you.
+ - **Plugins**
    <br/>
-   (In other words, the page is (re-)rendered to HTML every time the user requests the page.)
- - *DOM-static*
+   Plugins can modify Reframe to a great extent.
+   There are plugins for using Reframe with React Router v4, TypeScript, PostCSS, etc.
+ - **Customizable**
    <br/>
-   The page is not hydrated.
+   Reframe allows you to easily and fully customize the webpack config, the server, the browser entry, the Node.js entry, the routing, etc.
+ - **Performance**
    <br/>
-   (In other words, the DOM doesn't have any React component attached to it and the DOM will not change.)
- - *DOM-dynamic*
-   <br/>
-   The page is hydrated.
-   <br/>
-   (In other words, React components are attached to the DOM and the page's DOM will eventually be updated by React.)
+   Reframe creates high performance apps by doing
+   code splitting,
+   optimal HTTP caching,
+   by pre-rendering pages to HTML,
+   and by statically rendering views.
 
-This fine-grain control over the "static-ness" of your pages gives you the ability to implement all app types.
-
-For example, you can create:
- - Server-side rendered apps.
-   <br/>
-   (In other words HTML-dynamic apps: All pages are configured to be HTML-dynamic.)
- - Static websites.
-   <br/>
-   (In other words HTML-static apps: All pages are configured to be HTML-static.)
-   <br/>
-   Since all pages are rendered to HTML at build-time, no Node.js server is needed.
-   These apps can be deployed to static website hostings such as GitHub Pages or Netlify.
- - DOM-static apps
-   <br/>
-   (In other words, apps where all pages are configured to be DOM-static.)
-   <br/>
-   Since the page is not hydrated, React is not loaded in the browser.
-   No (or almost no) JavaScript is loaded in the browser.
- - Hybrid apps.
-   <br/>
-   An app can have pages of different types:
-   Some pages can be configured to be HTML-static, some pages to be HTML-dynamic, some others to be DOM-static, and some to be DOM-dynamic.
-   You can for example configure your landing page to be HTML-static and DOM-static,
-   your product page to be HTML-dynamic and DOM-static,
-   and your product search page to be HTML-static and DOM-dynamic.
-
-Reframe is the only React framework that supports all app types.
-
-> Instead of learning different frameworks to create different types of apps,
-> you learn Reframe once to be able to create all types of apps.
-
-#### Customization
-
-Reframe is designed with easy customization in mind,
-and the following examples are easy to achieve:
- - Custom server
-   - Add server endpoints: RESTful/GraphQL API endpoints, authentication endpoints, etc.
-   - Custom hapi server config. (Reframe uses the hapi server framework by default.)
-   - Use a process manager such as PM2.
-   - etc.
- - Custom browser JavaScript
-   - Add error logging, analytics, etc.
-   - Full control of the hydration process.
-   - etc.
- - Custom transpiling & bundling
-   - Reframe can be used with almost any webpack config. (Reframe assumes pretty much nothing about the webpack config.)
-   - TypeScript support
-   - CSS preprocessors support, such as PostCSS, SASS, etc.
-   - etc.
- - Custom routing library. (Reframe is based on React Router by default.)
- - Custom view library such as Preact.
-
-#### Easy Escape
-
-Every framework can be escaped from but the escape-cost can vary dramatically.
-The escape-cost can be measured by two criteria:
- 1. How much code can be re-used after the escape?
- 2. How progressively can the framework be escaped?
-
-For example, if no code can be re-used after escaping a framework, then that framework has a very high escape-cost.
-In other words, that framework strongly locks you in.
-
-Let's measure Reframe's escape-cost.
-
-###### Code re-use after escape
-
-Reframe is built on top of widely-used and high-quality "Do One Thing and Do It Well" (DOTADIW) libraries such as webpack, hapi, React, React Router, etc.
-
-Reframe mostly gets out of the way between your code and these DOTADIW libraries:
-With Reframe,
-most of the code you write directly uses these DOTADIW libraries, independently of Reframe.
-
-For example,
-you would add RESTFul API endpoints by directly using hapi's interface.
-The code implementing the RESTFul API is then entirely independent of Reframe and can be fully re-used after escaping Reframe.
-(Technically Reframe is, on the server-side, mostly just a hapi plugin; Most of your server code will use hapi directly, know nothing about Reframe, and will be re-usable after escaping Reframe.)
-
-> Most of your code can be re-used after escaping Reframe.
-
-When worrying about framework lock-in, one of the main question to ask yourself is "am I writing code against an interface introduced by the framework or against an interface of a DOTADIW library?".
-If the latter is the case, then you are not locking yourself into the framework.
-
-###### Progressive escape
-
-Reframe consists of three packages:
- - `@reframe/build` that transpiles code and bundles browser assets.
- - `@reframe/server` that creates the server.
- - `@reframe/browser` that handles the browser side and hydrates the page.
-
-Each of these packages can be replaced with code of your own.
-
-For example,
-you can replace Reframe's server `@reframe/server` with your own server implementation.
-At that point,
-you have full control over the server,
-while still using the rest of Reframe.
-
-Similarly,
-if you replace Reframe's build `@reframe/build` with your own build implementation,
-then you have full control over the build step,
-while still using the rest of Reframe.
-
-> Reframe can be escaped in a progressive manner.
-
-By replacing all these three packages with code of your own, you effectively escape Reframe entirely.
-
-The Customization Manual explains how to escape from these three packages and includes examples such as:
- - Entirely custom build using Rollup (instead of webpack and by getting rid of `@reframe/build`).
- - Entirely custom server using Express (instead of hapi and by getting rid of `@reframe/server`).
- - Entirely custom browser-side code (by getting rid of `@reframe/browser`).
-
-###### Meteor, the counter example
-
-On the other side of the escape-cost spectrum, there is Meteor.
-
-It consists of many parts that you can only use if you use the entire Meteor stack.
-For example, you can use its build system or its server only if you use Meteor in its entirety.
-This means that, if you want to escape Meteor, you will have to re-write all code related to these works-only-with-Meteor parts.
-
-It has also not been designed with loosely coupled parts;
-With Meteor, it's mostly either all-in or all-out.
-In other words, you can't escape in a progressive manner.
+The [Reframe Rational](/docs/reframe-rational.md) document goes into the details of these perks.
 
 
-
-#### Performance
-
-- **Code splitting**
-  <br/>
-  Every page loads two scripts:
-  One script that is shared and cached across all pages
-  (which includes common code such as React and polyfills)
-  and a second script that includes the React components of the page.
-  This means that a KB-heavy page won't affect the KB-size of other pages.
-- **Optimal HTTP caching**
-  <br/>
-  Every dynamic server response is cached with a ETag header,
-  and every static server response is indefinitely cached.
-  (Static assets are served under hashed URLs with the `Cache-Control` header set to `immutable` and `max-age`'s maximum value.)
-- **DOM-static pages**
-  <br/>
-  A page can be configured to be rendered only on the server.
-  These pages are faster to load as the page isn't hydrated and
-  React is not loaded in the browser.
-- **Partial DOM-dynamic pages**
-  <br/>
-  A page can be configured so that only certain parts of the page are hydrated.
-  This makes the hydration of the page quicker
-  and less JavaScript is loaded in the browser.
-  (Only the React components of the hydrated parts are loaded.)
-- **HTML-static pages**
-  <br/>
-  A page can be configured to be rendered to HTML at build-time instead of request-time.
-  In other words, the page is rendered to HTML only once, when Reframe is building the frontend.
-  The HTML is statically served and the load time is decreased.
-- **SSR**
-  <br/>
-  Pages are rendered to HTML before being hydrated, decreasing the (perceived) load time.
-
-
-
-### Reframe Project Scope
-
-Reframe takes care of:
-
- - **Building**
-   <br/>
-   Reframe transpiles and bundles. (Uses webpack.)
- - **Server**
-   <br/>
-   Reframe sets up a Node.js server serving static assets and your pages' HTML. (Uses hapi.)
- - **Routing**
-   <br/>
-   Reframe routes URLs to your pages.
-
-Reframe **doesn't** take care of:
-
- - View logic / state management.
-   <br/>
-   It's up to you to manage the state of your views (or use Redux / MobX).
- - Database.
-   <br/>
-   It's up to you to create, populate, and query databases.
-   (You can add RESTFul/GraphQL API endpoints to the hapi server that Reframe creates.)
-
-
-### Plugins
-
-###### Languages
- - [@reframe/typescript](/typescript) - Use Reframe with TypeScript.
- - [@reframe/postcss](/postcss) - Use Reframe with PostCSS.
-
-###### Routing
- - [@reframe/react-router](/react-router) - Use React Router's components.
- - [@reframe/crossroads](/crossroads) - Use Reframe with [Crossroads.js](https://github.com/millermedeiros/crossroads.js).
- - [@reframe/path-to-regexp](/path-to-regexp) - Use Reframe with [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp).
-
-###### Kits
- - [@reframe/default-kit](/default-kit) - Reframe's default kit.
-
-###### View renderers
- - [@reframe/react](/react) - Use Reframe with React.
 
 ### Quick Start
 


### PR DESCRIPTION
Ok, I wanted you to take a look at this before I went any further and get your opinions.

I've modified the CLI so that if you just type `reframe` or any argument except for `reframe start` or `reframe init` it will send back an error.

With `reframe start`, I simply changed the name of your run() function to start and moved it behind that command instead of running by default.

With `reframe init projectName` I have it creating the scaffold structure we discussed:

- projectName
  - app
    - views
      - homeView.js
    - pages
      - homePage.js

With that said, I think the createScaffold() function is a little messy with all the nested callbacks.  If you don't have a better suggestion, I think we should consider also including [fs-extra](https://www.npmjs.com/package/fs-extra) as a dependency since it is a direct replacement for Node's fs module and will recursively go back and create the file structure with a single command.  Just let me know if you want me to add that and I'll go back and clean that up.

Also, I don't have it creating a `package.json` file yet as I wanted to get you opinion on what you wanted it to look like.  We can discuss that later and figure out what all we want to include in that.

For the `homeView.js` and `homePage.js` I'm not sure if I did everything correctly to link those two or if I'm missing some other boilerplate code we want to add.  Just let me know what you think!
