### PR TITLE
fixes issue #15, adds log option to reframe start

### DIFF
--- a/core/cli/cli.js
+++ b/core/cli/cli.js
@@ -24,9 +24,10 @@ program
 program
     .command('start')
     .description('starts dev server on localhost')
+    .option("-l, --log", "prints build and page information")
     .action( () => {
         argValue = 'start';
-        start();
+        start(options.log);
     });
 
 program
@@ -43,7 +44,7 @@ if (typeof argValue === 'undefined') {
     process.exit(1);
 }
 
-function start() {
+function start(showHapiServerLog) {
     const {opts, cwd} = get_cli_args();
 
     if( opts.prod ) {
@@ -54,10 +55,10 @@ function start() {
 
     const reframeConfig = reframeConfigPath && require(reframeConfigPath);
 
-    startHapiServer({pagesDirPath, reframeConfig, appDirPath});
+    startHapiServer({pagesDirPath, reframeConfig, appDirPath}, showHapiServerLog);
 }
 
-async function startHapiServer({pagesDirPath, reframeConfig, appDirPath}) {
+async function startHapiServer({pagesDirPath, reframeConfig, appDirPath}, showHapiServerLog) {
     const {createHapiServer} = require('@reframe/server/createHapiServer');
 
     const {server} = await createHapiServer({
@@ -65,6 +66,7 @@ async function startHapiServer({pagesDirPath, reframeConfig, appDirPath}) {
         reframeConfig,
         appDirPath,
         logger: {onFirstCompilationSuccess: log_build_success},
+        showHapiServerLog
     });
 
     await server.start();


### PR DESCRIPTION
Ok, added log command and just passing it down the chain from `start()` to `startHapiServer()` to `createHapiServer()`.  If it would be preferable, I could instead variable at the top of the file and call that instead, but it seems cleaner to just pass it down the chain, but that decision is up to you!

Also, one thing to keep in mind, if the log command is not passed, then options.log will be undefined, not false.  I'm not sure if that will cause any issues anywhere, but if you need it to be false, I can add a check on the initial `start()` call and set it to false if log command isn't passed?  Just let me know what you think!